### PR TITLE
Add minimal setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+from distutils.core import setup
+setup(
+    name='Stockfighter',
+    version='0.1',
+    packages=['Stockfighter'],
+)


### PR DESCRIPTION
It doesn't handle deps (such a thing would be tricky because of the `enum` package problem), but at least gives the option of installing with pip.
